### PR TITLE
disabled parent-iframe test for iphone devices

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -42,6 +42,9 @@ def before_scenario(context, scenario):
         scenario.skip("SCENARIO SKIPPED as iOS system and Safari is required for ApplePay test")
     if "animated_card_repo_test" in scenario.tags:
         context.is_field_in_iframe = False
+    #ToDo Temporarily disabled parent-iframe test. Problem with cress-origin restriction on ios
+    if "parent_iframe" in scenario.tags and ('iP' in CONFIGURATION.REMOTE_DEVICE):
+        scenario.skip("Temporarily disabled test ")
     else:
         context.is_field_in_iframe = True
     if 'config_skip_jsinit' not in scenario.tags:


### PR DESCRIPTION
There is problem with test (App is embedded in another iframe) on iphone devices. 
_Error while executing atom: An unknown server-side error occurred while processing the command. Original error: Blocked a frame with origin "https://merchant.[secure].net" from accessing a frame with origin "https://merchant.[secure].net". The frame being accessed set "document.domain" to "[secure].net", but the frame requesting access did not. Both must set "document.domain" to the same value to allow access._

I've commented it out for now but we have to make some changes in js-payments repo.