### PR TITLE
added remote debugging capability to chrome

### DIFF
--- a/utils/driver_factory.py
+++ b/utils/driver_factory.py
@@ -105,4 +105,6 @@ class SeleniumDriver(Driver):
             kwargs['chrome_options'].add_argument('--no-sandbox')
             kwargs['chrome_options'].add_argument('--disable-dev-shm-usage')
             kwargs['chrome_options'].add_argument('--ignore-certificate-errors')
+            kwargs['chrome_options'].add_argument('--remote-debugging-address=0.0.0.0')
+            kwargs['chrome_options'].add_argument('--remote-debugging-port=9222')
         return driver.value(**kwargs)


### PR DESCRIPTION
1. To access remote debuging run tests with `docker-compose run -p 9222:9222 tests poetry run behave features --tags=smoke_test`. 
2. You should insert `time.sleep(...)` somewhere to pause test execution. 
3. Open the browser and go to `http://localhost:9222`.

Enjoy 😉 